### PR TITLE
Revert "Feature#69"

### DIFF
--- a/seml-mode.el
+++ b/seml-mode.el
@@ -47,7 +47,7 @@
   :group 'lisp
   :prefix "seml-")
 
-(defconst seml-mode-version "1.3.5"
+(defconst seml-mode-version "1.3.4"
   "Version of `seml-mode'.")
 
 (defcustom seml-mode-hook nil
@@ -232,7 +232,7 @@ XPATH is now supported below forms
     (unwind-protect
         (progn
           (with-current-buffer source-buf
-            (insert (or codestr ""))
+            (insert codestr)
             (funcall majormode)
             (font-lock-ensure)
             (ignore-errors


### PR DESCRIPTION
seml-htmlize may assume that a string is passed as an argument, this correspondence is incorrect and should be handled by the caller if necessary.
Reverts conao3/seml-mode.el#70
